### PR TITLE
Improvement the Updatecli pipeline

### DIFF
--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -40,6 +40,13 @@ sources:
         # the following rule, should do the trick
         pattern: ">0.1"
 
+  epinio-chart:
+    kind: helmchart
+    name: Get latest Epinio Helm chart version
+    spec:
+      url: https://epinio.github.io/helm-charts/
+      name: epinio
+
   epinioSubVersion:
     name: Get latest Epinio version
     kind: githubrelease
@@ -75,36 +82,26 @@ targets:
       matchpattern: 'https://github.com/epinio/epinio/releases/download/(.*)/'
       replacepattern: 'https://github.com/epinio/epinio/releases/download/{{ source "epinio" }}/'
     scmid: default
-    sourceid: epinio
+    disablesourceinput: true
 
   epinio-version:
     name: 'Update Epinio Version Information'
     kind: file
-    sourceid: epinio
+    disablesourceinput: true
     spec:
       file: docs/installation/install_epinio_cli.md
       matchpattern: 'Epinio Version: (.*)'
       replacepattern: 'Epinio Version: {{ source "epinio" }}'
     scmid: default
 
-  ep-on-rd-download-url:
-    name: 'Update Helm chart URL'
-    kind: file
-    spec:
-      file: docs/installation/other_inst_scenarios/install_epinio_on_rancher_desktop.md
-      matchpattern: '\(https://github.com/epinio/helm-charts/releases/tag/epinio-(.*)\)'
-      replacepattern: '\(https://github.com/epinio/helm-charts/releases/tag/epinio={{ source "epinio" }}\)'
-    scmid: default
-    sourceid: epinio
-
   ep-on-rd-epinio-version:
     name: 'Update Epinio Version for EP on RD'
     kind: file
-    sourceid: epinio
+    disablesourceinput: true
     spec:
       file: docs/installation/other_inst_scenarios/install_epinio_on_rancher_desktop.md
-      matchpattern: '\[epinio helm chart (.*)\]'
-      replacepattern: '\[epinio helm chart {{ source "epinio" }}\]'
+      matchpattern: '\[epinio helm chart (.*)\]\(https://github.com/epinio/helm-charts/releases/tag/epinio-(.*)\)'
+      replacepattern: '[epinio helm chart {{ source "epinio-chart" }}](https://github.com/epinio/helm-charts/releases/tag/epinio-{{ source "epinio-chart" }})'
     scmid: default
 
   # Required yarn to be installed


### PR DESCRIPTION
Improvement the Updatecli pipeline
    
* Merge two targets
* Replace `sourceid` by `disablesourceinput` when sourceid is not used
* Monitor helm-chart

To test this PR

1. Install [Updatecli](https://www.updatecli.io/docs/prologue/installation/)
2. Get GitHub Personnal Access Token
3. Run `export UPDATECLI_GITHUB_TOKEN=<your token>`
4. Run `export UPDATECLI_GITHUB_ACTOR=<your username>`
5. Run `updatecli diff --config updatecli/updatecli.d/installation.yaml `
 
<details><summary> Console Output</summary>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/installation.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



#####################################################
# BUMP EPINIO VERSION IN INSTALLATION DOCUMENTATION #
#####################################################


SOURCES
=======

epinioSubVersion
----------------
Searching for version matching pattern ">0.1"
✔ GitHub release version "v1.10.0" found matching pattern ">0.1" of kind "semver"


CHANGELOG:
----------

Release published on the 2023-09-26 10:15:41 +0000 UTC at the url https://github.com/epinio/epinio/releases/tag/v1.10.0

# What's Changed

This version adds support for **private** Git repositories. With the new `epinio gitconfig` command you can provide specific configurations and tokens used with your git server.  
It also adds support for accessing Services Helm charts stored in private repositories and registries.  

A new `--registry` flag was added to the `app export` command to support the App image and chart export to external OCI registries.

For easier debugging new `--trace-file` and `--trace-output` flags to redirect and format debugging logs are now available.  

The `epinio configuration [list|show]` and the `epinio namespace [list|show]` commands now support a new `--output=json` flag.


 Support for private Helm charts requires updating of the Epinio Service CRDs by running the following command:

```
kubectl apply -f https://github.com/epinio/epinio/releases/download/v1.10.0/service-crd.yaml
```

See [Helm HIP-0011](https://github.com/helm/community/blob/main/hips/hip-0011.md) for more information about this.

:warning:   **Note**

This version drops backward compatibility for old HelmController-based services, and support for the old mount paths for service based configurations.

## 🚀 Features

- Added support for Git configurations (#2503) and new `epinio gitconfig` command (#2521)
- Added `--registry` flag to `app export` to support external OCI registries (#2509)
- Added support for private Helm repositories and registries (#2530)
- Added Letsencrypt staging ClusterIssuer (#2565)
- Added `--output=json` flag to `epinio configuration [list|show]` (#2562) and `epinio namespace [list|show]` (#2547)
- Added display of credentials in `epinio service show` command (#2513)
- Added `--trace-file` and `--trace-output` flags to redirect and format debugging logs (#2512)
- Added `Update` and `Replace` APIs for Service custom values (#2522)
- Added `https` fallback to `epinio login` (#2531)
- Added support for configurable size of staging volumes (#2508)
- Added optional `restart` field to `AppUpdate` API (#2457)
- Better error message for missing `settings.yaml` file (#2502)
- Added support in service `--chart-value` for arrays and nested maps (#2485)
- Added `branch` and `revision` fields to ImportGit API (#2487)
- Added git URL and git provider validation (#2473)
- [UI] Supply custom Service chart values (strings, numbers, integers, bools) when creating a service (https://github.com/epinio/ui/issues/338)
- [UI] Added progress bar during `app export` (https://github.com/epinio/ui/issues/223 https://github.com/epinio/ui/issues/312)
- [UI] Improved export performance of App chart and images (https://github.com/epinio/ui/issues/254)
- [UI] Show correct page in Commits table when navigating in Git applications edit (https://github.com/epinio/ui/issues/253)
- [UI] Improved service unbind checking the current status (https://github.com/epinio/ui/issues/342)

## 🐛 Bug Fixes

- Fixed a mishandling of apps in `service delete --unbind` (#2566)
- Fixed `customTlsIssuer` value and create Letsencrypt ClusterIssuer only when requested (#2565)
- Fixed mishandling of `app export` jobs on cancellation, and for multiple concurrent requests (#2517)
- Fixed mishandling of environment variables with spaces during staging (#2493)
- Fixed missing failure on `service port-forward` with non-existing service (#2486)
- [UI] Fixed abort of export when clicking outside of the modal (https://github.com/epinio/ui/issues/301)
- [UI] Fixed missing Catalog Service and bound app fields in service detail page (https://github.com/epinio/ui/issues/296)
- [UI] Fixed redeploy of failed app during staging (https://github.com/epinio/ui/issues/277)
- [UI] Fixed `min` property in metrics calculation being always zero (https://github.com/epinio/ui/issues/274)
- [UI] Fixed blank screen after clicking on namespace link on Instances page (https://github.com/epinio/ui/issues/324)
- [UI] Fixed Custom Variables validation in Application edit (for some browsers) (https://github.com/epinio/ui/issues/299)

## 🧰 Maintenance

- Typo fixed (#2585)
- Fixed skopeo image reference due to upstream removing `v1.10` (#2529)
- Fixed goreleaser deprecations (#2520)
- Removed Kubernetes API access from `settings update-ca` command (#2506)
- Dependency updates (#2501)
- Updated Dex to `0.15.2` (#2483)
- Removed remaining support for helmcontroller-based services (#2479)
- Dropped old mount paths for service-based configurations (#2482)

# Usage

More info can be found in the [installation instructions](https://docs.epinio.io/installation/install_epinio).



epinio-chart
------------
Searching for version matching pattern "*"
✔ Helm Chart "epinio" version "1.10.0" is found from repository "https://epinio.github.io/helm-charts/"

Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: epinio
Epinio deploys Kubernetes applications directly from source code in one step.
Project Home: https://github.com/epinio/epinio

Version created on the 2023-09-25 09:42:07.166517452 &#43;0000 UTC

Sources:

* https://github.com/epinio/epinio



URL:

* https://github.com/epinio/helm-charts/releases/download/epinio-1.10.0/epinio-1.10.0.tgz




CHANGELOG:
----------

Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: epinio
Epinio deploys Kubernetes applications directly from source code in one step.
Project Home: https://github.com/epinio/epinio

Version created on the 2023-09-25 09:42:07.166517452 &#43;0000 UTC

Sources:

* https://github.com/epinio/epinio



URL:

* https://github.com/epinio/helm-charts/releases/download/epinio-1.10.0/epinio-1.10.0.tgz




epinio
------
Searching for version matching pattern ">0.1"
✔ GitHub release version "v1.10.0" found matching pattern ">0.1" of kind "semver"


CHANGELOG:
----------

Release published on the 2023-09-26 10:15:41 +0000 UTC at the url https://github.com/epinio/epinio/releases/tag/v1.10.0

# What's Changed

This version adds support for **private** Git repositories. With the new `epinio gitconfig` command you can provide specific configurations and tokens used with your git server.  
It also adds support for accessing Services Helm charts stored in private repositories and registries.  

A new `--registry` flag was added to the `app export` command to support the App image and chart export to external OCI registries.

For easier debugging new `--trace-file` and `--trace-output` flags to redirect and format debugging logs are now available.  

The `epinio configuration [list|show]` and the `epinio namespace [list|show]` commands now support a new `--output=json` flag.


 Support for private Helm charts requires updating of the Epinio Service CRDs by running the following command:

```
kubectl apply -f https://github.com/epinio/epinio/releases/download/v1.10.0/service-crd.yaml
```

See [Helm HIP-0011](https://github.com/helm/community/blob/main/hips/hip-0011.md) for more information about this.

:warning:   **Note**

This version drops backward compatibility for old HelmController-based services, and support for the old mount paths for service based configurations.

## 🚀 Features

- Added support for Git configurations (#2503) and new `epinio gitconfig` command (#2521)
- Added `--registry` flag to `app export` to support external OCI registries (#2509)
- Added support for private Helm repositories and registries (#2530)
- Added Letsencrypt staging ClusterIssuer (#2565)
- Added `--output=json` flag to `epinio configuration [list|show]` (#2562) and `epinio namespace [list|show]` (#2547)
- Added display of credentials in `epinio service show` command (#2513)
- Added `--trace-file` and `--trace-output` flags to redirect and format debugging logs (#2512)
- Added `Update` and `Replace` APIs for Service custom values (#2522)
- Added `https` fallback to `epinio login` (#2531)
- Added support for configurable size of staging volumes (#2508)
- Added optional `restart` field to `AppUpdate` API (#2457)
- Better error message for missing `settings.yaml` file (#2502)
- Added support in service `--chart-value` for arrays and nested maps (#2485)
- Added `branch` and `revision` fields to ImportGit API (#2487)
- Added git URL and git provider validation (#2473)
- [UI] Supply custom Service chart values (strings, numbers, integers, bools) when creating a service (https://github.com/epinio/ui/issues/338)
- [UI] Added progress bar during `app export` (https://github.com/epinio/ui/issues/223 https://github.com/epinio/ui/issues/312)
- [UI] Improved export performance of App chart and images (https://github.com/epinio/ui/issues/254)
- [UI] Show correct page in Commits table when navigating in Git applications edit (https://github.com/epinio/ui/issues/253)
- [UI] Improved service unbind checking the current status (https://github.com/epinio/ui/issues/342)

## 🐛 Bug Fixes

- Fixed a mishandling of apps in `service delete --unbind` (#2566)
- Fixed `customTlsIssuer` value and create Letsencrypt ClusterIssuer only when requested (#2565)
- Fixed mishandling of `app export` jobs on cancellation, and for multiple concurrent requests (#2517)
- Fixed mishandling of environment variables with spaces during staging (#2493)
- Fixed missing failure on `service port-forward` with non-existing service (#2486)
- [UI] Fixed abort of export when clicking outside of the modal (https://github.com/epinio/ui/issues/301)
- [UI] Fixed missing Catalog Service and bound app fields in service detail page (https://github.com/epinio/ui/issues/296)
- [UI] Fixed redeploy of failed app during staging (https://github.com/epinio/ui/issues/277)
- [UI] Fixed `min` property in metrics calculation being always zero (https://github.com/epinio/ui/issues/274)
- [UI] Fixed blank screen after clicking on namespace link on Instances page (https://github.com/epinio/ui/issues/324)
- [UI] Fixed Custom Variables validation in Application edit (for some browsers) (https://github.com/epinio/ui/issues/299)

## 🧰 Maintenance

- Typo fixed (#2585)
- Fixed skopeo image reference due to upstream removing `v1.10` (#2529)
- Fixed goreleaser deprecations (#2520)
- Removed Kubernetes API access from `settings update-ca` command (#2506)
- Dependency updates (#2501)
- Updated Dex to `0.15.2` (#2483)
- Removed remaining support for helmcontroller-based services (#2479)
- Dropped old mount paths for service-based configurations (#2482)

# Usage

More info can be found in the [installation instructions](https://docs.epinio.io/installation/install_epinio).




TARGETS
========

download-url
------------

**Dry Run enabled**

✔ - all contents from 'file' and 'files' combined already up to date

docusaurus
----------

**Dry Run enabled**

The shell 🐚 command "/bin/sh /tmp/updatecli/bin/509c260b9784f02ae482811aef0208b2d403f03d271331b93b04594784732039.sh" ran successfully with the following output:
----
----
No change detected
✔ - ran shell command "./updatecli/scripts/docusaurus.sh 1.10.0"

ep-on-rd-epinio-version
-----------------------

**Dry Run enabled**

"docs/installation/other_inst_scenarios/install_epinio_on_rancher_desktop.md" updated with [dry run] content "[epinio helm chart 1.10.0](https://github.com/epinio/helm-charts/releases/tag/epinio-1.10.0)"

```
--- docs/installation/other_inst_scenarios/install_epinio_on_rancher_desktop.md
+++ docs/installation/other_inst_scenarios/install_epinio_on_rancher_desktop.md
@@ -8,7 +8,7 @@
 
 This How-to uses the following versions:
 
-* [epinio helm chart 1.0.0](https://github.com/epinio/helm-charts/releases/tag/epinio-1.0.0)
+* [epinio helm chart 1.10.0](https://github.com/epinio/helm-charts/releases/tag/epinio-1.10.0)
 * Rancher Desktop 1.4.1
 
 ## Rancher Desktop prerequisites

```

⚠ - 1 file(s) updated with "[epinio helm chart 1.10.0](https://github.com/epinio/helm-charts/releases/tag/epinio-1.10.0)":
	* docs/installation/other_inst_scenarios/install_epinio_on_rancher_desktop.md

epinio-version
--------------

**Dry Run enabled**

✔ - all contents from 'file' and 'files' combined already up to date


ACTIONS
========

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

REPORTS:



⚠ Bump Epinio version in installation documentation:
	Source:
		✔ [epinio] Get latest Epinio version
		✔ [epinio-chart] Get latest Epinio Helm chart version
		✔ [epinioSubVersion] Get latest Epinio version
	Target:
		✔ [docusaurus] Set latest docusaurus version
		✔ [download-url] Update Epinio Installation URL
		⚠ [ep-on-rd-epinio-version] Update Epinio Version for EP on RD
		✔ [epinio-version] Update Epinio Version Information


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1


```

</details>

Signed-off-by: John Krug <john.krug@suse.com>